### PR TITLE
Upgrade to Mediawiki 1.39 | SIWE | OIDC

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,6 @@ LETSENCRYPT_EMAIL=you@youremaildomain.com
 MEDIAWIKI_PORT=9352
 
 SIWEOIDC_PORT=9353
-SIWEOIDC_HOST=siwe.yourdomain.com
+SIWEOIDC_HOST=localhost
 SIWEOIDC_BASE_URL="SIWEOIDC_SERVER"
 SIWEOIDC_DEFAULT_CLIENTS='{siwe="{\"secret\":\"siweaqua\", \"metadata\": {\"redirect_uris\": [\"PKC_SERVER/index.php/Special:PluggableAuthLogin\"]}}"}'

--- a/.env.template
+++ b/.env.template
@@ -1,44 +1,10 @@
 MEDIAWIKI_HOST=pkc.yourdomain.com
-EAUTH_HOST=eauth.yourdomain.com
 LETSENCRYPT_EMAIL=you@youremaildomain.com
 
 # MediaWiki port Number
 MEDIAWIKI_PORT=9352
 
-# Eauth port
-EAUTH_PORT=8089
-
-EAUTH_BANNER=Personal Knowledge Container
-EAUTH_LOGGING=true
-EAUTH_MESSAGE_PREFIX=Authenticate with your Ethereum wallet
-EAUTH_RPC_URL=https://rinkeby.infura.io/
-EAUTH_SESSION_TIMEOUT=60000
-EAUTH_SECRET=secret
-
-# Show wallet selection or injected only
-EAUTH_WALLETMODAL=false
-EAUTH_COMPONENTS_CONTRACT=false
-EAUTH_COMPONENTS_ENS=false
-EAUTH_COMPONENTS_OAUTH=true
-EAUTH_COMPONENTS_QRCODE=false
-EAUTH_COMPONENTS_UI=true
-
-EAUTH_DB_DIALECT=mysql
-EAUTH_DB_HOST=database
-EAUTH_DB_PORT=3306
-EAUTH_DB_USER=wikiuser
-EAUTH_DB_PASSWORD=example
-EAUTH_DB_NAME=eauth
-
-EAUTH_OAUTH_DB_DIALECT=mysql
-EAUTH_OAUTH_DB_HOST=database
-EAUTH_OAUTH_DB_PORT=3306
-EAUTH_OAUTH_DB_USER=wikiuser
-EAUTH_OAUTH_DB_PASSWORD=example
-EAUTH_OAUTH_DB_NAME=eauth
-
-# Insert a client config when the server starts
-EAUTH_CLIENT_NAME=pkc
-EAUTH_CLIENT_ID=pkc
-EAUTH_CLIENT_SECRET=pkc
-EAUTH_REDIRECT_URI=PKC_SERVER/index.php/Special:OAuth2Client/callback
+SIWEOIDC_PORT=9353
+SIWEOIDC_HOST=siwe.yourdomain.com
+SIWEOIDC_BASE_URL="SIWEOIDC_SERVER"
+SIWEOIDC_DEFAULT_CLIENTS='{siwe="{\"secret\":\"siweaqua\", \"metadata\": {\"redirect_uris\": [\"PKC_SERVER/index.php/Special:PluggableAuthLogin\"]}}"}'

--- a/aqua/extraAquaSettings.php
+++ b/aqua/extraAquaSettings.php
@@ -56,6 +56,9 @@ $wgPluggableAuth_Config['Login with Ethereum'] = [
    ]
 ];
 
+// Allow OIDC to create users
+$GLOBALS['wgGroupPermissions']['*']['autocreateaccount'] = true;
+
 $wgWhitelistRead = ['Aqua Demo', 'Main Page', 'Special:OAuth2Client', 'Special:OAuth2Client/redirect', 'Spezial:OAuth2Client', 'Spezial:OAuth2Client/redirect', 'Special:PluggableAuthLogin', 'Spezial:PluggableAuthLogin'];
 # We need a trailing newline below so that the resulting LocalSettings.php looks nice. Don't delete!
 

--- a/aqua/extraAquaSettings.php
+++ b/aqua/extraAquaSettings.php
@@ -59,6 +59,10 @@ $wgPluggableAuth_Config['Login with Ethereum'] = [
 // Allow OIDC to create users
 $GLOBALS['wgGroupPermissions']['*']['autocreateaccount'] = true;
 
+// Helper vars to replace SIWE URL for in-container calls
+$wgSIWEhost = getenv( 'SIWEOIDC_HOST', true ) ?: getenv( 'SIWEOIDC_HOST' ) ?: 'localhost';
+$wgSIWEport = getenv( 'SIWEOIDC_PORT', true ) ?: getenv( 'SIWEOIDC_PORT' ) ?: 'localhost';
+
 $wgWhitelistRead = ['Aqua Demo', 'Main Page', 'Special:OAuth2Client', 'Special:OAuth2Client/redirect', 'Spezial:OAuth2Client', 'Spezial:OAuth2Client/redirect', 'Special:PluggableAuthLogin', 'Spezial:PluggableAuthLogin'];
 # We need a trailing newline below so that the resulting LocalSettings.php looks nice. Don't delete!
 

--- a/aqua/extraAquaSettings.php
+++ b/aqua/extraAquaSettings.php
@@ -19,26 +19,6 @@ $wgGroupPermissions['*']['embed_pdf'] = true;
 
 $wgShowExceptionDetails = true;
 
-# Modify the default Login button to become OAuth2 login.
-function ModifyDefaultLogin(&$personal_urls, &$wgTitle) {
-	$keys = ["login", "anonlogin", "login-private"];
-	foreach ($keys as $key) {
-		if (array_key_exists($key, $personal_urls)) {
-			$old_url_arr = explode("&", $personal_urls[$key]["href"]);
-			$params = "";
-			if (count($old_url_arr) > 1) {
-				// Add URL params only when they exist.
-				$params = "&" . $old_url_arr[1];
-			}
-			$personal_urls[$key]["href"] = "/index.php?title=Special:OAuth2Client/redirect" . $params;
-		}
-	}
-
-	return true;
-}
-
-$wgHooks['PersonalUrls'][] = 'ModifyDefaultLogin';
-
 # Disable reading by anonymous users using `./pkc setup --private -w WALLET_ADDRESS`
 # WARNING: If false, remote verification via API will be denied access.
 $wgGroupPermissions['*']['read'] = true;
@@ -58,25 +38,24 @@ $wgGroupPermissions['*']['createaccount'] = false;
 #
 # The following params are used only for the OAuth2 client extension
 # configuration.
-$EAUTH_PORT = 'EAUTH_PORT_PLACEHOLDER';
 $pkcServer = 'PKC_SERVER';
 $parsedPkcServer = parse_url($pkcServer);
 $pkcHost = $parsedPkcServer['scheme'] . '://' . $parsedPkcServer['host'];
-$eauthServer = "$pkcHost:$EAUTH_PORT";
+$siweServer = "SIWE_SERVER_PLACEHOLDER";
+
+# For OIDC
 # TODO generate a better secret
-$wgOAuth2Client['client']['id']     = 'pkc';  # The client ID assigned to you by the provider
-$wgOAuth2Client['client']['secret'] = 'pkc';  # The client secret assigned to you by the provider
-$wgOAuth2Client['configuration']['authorize_endpoint']     = "$eauthServer/oauth/authorize"; // Authorization URL
-$wgOAuth2Client['configuration']['access_token_endpoint']  = "http://eauth:$EAUTH_PORT/oauth/token"; // Token URL
-$wgOAuth2Client['configuration']['api_endpoint']           = "http://eauth:$EAUTH_PORT/oauth/user"; // URL to fetch user JSON
-$wgOAuth2Client['configuration']['redirect_uri']           = "$pkcServer/index.php/Special:OAuth2Client/callback"; // URL for OAuth2 server to redirect to
+$wgPluggableAuth_Config['Login with Ethereum'] = [
+   'plugin' => 'OpenIDConnect',
+   'data' => [
+       'providerURL' => $siweServer,
+       'clientID' => 'siwe',
+       'clientsecret' => 'siweaqua',
+       'preferred_username' => 'preferred_username'
+   ]
+];
 
-$wgOAuth2Client['configuration']['username'] = 'address'; // JSON path to username
-$wgOAuth2Client['configuration']['email'] = 'email'; // JSON path to email
-
-$wgOAuth2Client['configuration']['scopes'] = 'openid email profile'; //Permissions
-$wgOAuth2Client['configuration']['service_login_link_text'] = 'Login with Ethereum wallet'; // the text of the login link
-$wgWhitelistRead = ['Aqua Demo', 'Main Page', 'Special:OAuth2Client', 'Special:OAuth2Client/redirect', 'Spezial:OAuth2Client', 'Spezial:OAuth2Client/redirect'];
+$wgWhitelistRead = ['Aqua Demo', 'Main Page', 'Special:OAuth2Client', 'Special:OAuth2Client/redirect', 'Spezial:OAuth2Client', 'Spezial:OAuth2Client/redirect', 'Special:PluggableAuthLogin', 'Spezial:PluggableAuthLogin'];
 # We need a trailing newline below so that the resulting LocalSettings.php looks nice. Don't delete!
 
 # The following lines are added to override a legacy MW behavior.

--- a/aqua/extraAquaSettings.php
+++ b/aqua/extraAquaSettings.php
@@ -51,7 +51,8 @@ $wgPluggableAuth_Config['Login with Ethereum'] = [
        'providerURL' => $siweServer,
        'clientID' => 'siwe',
        'clientsecret' => 'siweaqua',
-       'preferred_username' => 'preferred_username'
+       'preferred_username' => 'preferred_username',
+       'scope' => [ 'openid', 'profile' ],
    ]
 ];
 

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -14,8 +14,8 @@ while [ "$#" -gt 0 ]; do
             shift
             shift
             ;;
-        --eauth-server)
-            EAUTH_SERVER="$2"
+        --siweoidc-server)
+            SIWEOIDC_SERVER="$2"
             shift
             shift
             ;;
@@ -39,7 +39,7 @@ done
 # - EmbedVideo, because not working in MW 37
 # - SpamBlacklist because unnecessary spam protection
 BASE_EXTENSIONS="CategoryTree,Cite,CiteThisPage,Gadgets,ImageMap,InputBox,Interwiki,LocalisationUpdate,MultimediaViewer,Nuke,OATHAuth,PageImages,ParserFunctions,PDFEmbed,PdfHandler,Poem,Renameuser,ReplaceText,Scribunto,SecureLinkFixer,SyntaxHighlight_GeSHi,TemplateData,TextExtracts,TitleBlacklist,WikiEditor"
-EXTENSIONS="$BASE_EXTENSIONS,PDFEmbed,DataAccounting,MW-OAuth2Client"
+EXTENSIONS="$BASE_EXTENSIONS,PDFEmbed,DataAccounting,PluggableAuth,OpenIDConnect"
 
 admin_password="$(openssl rand -base64 20)"
 
@@ -72,6 +72,9 @@ install_media_wiki(){
                     "$WALLET_ADDRESS"
 }
 
+(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_39-4712c82.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
+(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_39-1884a12.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
+
 retry_counter=0
 while ! install_media_wiki; do
     if [ $retry_counter -gt 4 ]; then
@@ -94,12 +97,9 @@ fi
 # Specify PKC_SERVER
 sed -i "s|PKC_SERVER|$PKC_SERVER|" LocalSettings.php
 
-# Specify Eauth port
-sed -i "s/EAUTH_PORT_PLACEHOLDER/$EAUTH_PORT/" LocalSettings.php
-
-# Put in Eauth server if specified
-if [ -n "$EAUTH_SERVER" ]; then
-sed -i "s|eauthServer = .*|eauthServer = '$EAUTH_SERVER';|" LocalSettings.php
+# Put in SIWE server if specified
+if [ -n "$SIWEOIDC_SERVER" ]; then
+sed -i "s|siweServer = .*|siweServer = '$SIWEOIDC_SERVER';|" LocalSettings.php
 fi
 
 disable_extension() {

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -75,6 +75,9 @@ install_media_wiki(){
 (cd extensions && curl https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_39-4712c82.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
 (cd extensions && curl https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_39-1884a12.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
 
+echo "Running composer update"
+composer update --no-dev
+
 retry_counter=0
 while ! install_media_wiki; do
     if [ $retry_counter -gt 4 ]; then

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -72,13 +72,10 @@ install_media_wiki(){
                     "$WALLET_ADDRESS"
 }
 
-# https://www.mediawiki.org/wiki/Special:ExtensionDistributor/OpenIDConnect
-(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_39-194d805.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
-# https://www.mediawiki.org/wiki/Special:ExtensionDistributor/PluggableAuth
-(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_39-1884a12.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
-
 echo "Running composer update"
 composer update --no-dev
+echo "Applying patches"
+./apply-patches.sh
 
 retry_counter=0
 while ! install_media_wiki; do

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -72,7 +72,9 @@ install_media_wiki(){
                     "$WALLET_ADDRESS"
 }
 
-(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_39-4712c82.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
+# https://www.mediawiki.org/wiki/Special:ExtensionDistributor/OpenIDConnect
+(cd extensions && curl https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_39-194d805.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
+# https://www.mediawiki.org/wiki/Special:ExtensionDistributor/PluggableAuth
 (cd extensions && curl https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_39-1884a12.tar.gz > aaa.tar.gz && tar xf aaa.tar.gz && rm aaa.tar.gz)
 
 echo "Running composer update"

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -128,6 +128,7 @@ sed -i "s/wgEnableUploads = false;/wgEnableUploads = true;/" LocalSettings.php
 
 # Insert smart contract address to LocalSettings.php.
 echo "\$daSmartContractAddress = '0x45f59310ADD88E6d23ca58A0Fa7A55BEE6d2a611';" >> LocalSettings.php
+echo "\$daWalletAddress = '$WALLET_ADDRESS';" >> LocalSettings.php
 
 # Insert witness network to LocalSettings.php
 cat <<EOF >> LocalSettings.php

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -80,7 +80,7 @@ echo "Applying patches"
 retry_counter=0
 while ! install_media_wiki; do
     if [ $retry_counter -gt 4 ]; then
-        echo "MediaWiki intallation retries exceeded"
+        echo "MediaWiki installation retries exceeded"
         break
     fi
     retry_counter=$((retry_counter+1))

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -102,7 +102,7 @@ sed -i "s|PKC_SERVER|$PKC_SERVER|" LocalSettings.php
 
 # Put in SIWE server if specified
 if [ -n "$SIWEOIDC_SERVER" ]; then
-	sed -i "s|siweServer = .*|siweServer = '$SIWEOIDC_SERVER';|" LocalSettings.php
+sed -i "s|siweServer = .*|siweServer = '$SIWEOIDC_SERVER';|" LocalSettings.php
 fi
 
 disable_extension() {

--- a/aqua/install_pkc.sh
+++ b/aqua/install_pkc.sh
@@ -102,7 +102,7 @@ sed -i "s|PKC_SERVER|$PKC_SERVER|" LocalSettings.php
 
 # Put in SIWE server if specified
 if [ -n "$SIWEOIDC_SERVER" ]; then
-sed -i "s|siweServer = .*|siweServer = '$SIWEOIDC_SERVER';|" LocalSettings.php
+	sed -i "s|siweServer = .*|siweServer = '$SIWEOIDC_SERVER';|" LocalSettings.php
 fi
 
 disable_extension() {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,6 @@
 # DefaultSettings for MediaWiki
 # @see https://phabricator.wikimedia.org/source/mediawiki/browse/master/includes/DefaultSettings.php
 
-version: '3'
 services:
   database:
     container_name: micro-pkc-database-dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,7 @@
 # DefaultSettings for MediaWiki
 # @see https://phabricator.wikimedia.org/source/mediawiki/browse/master/includes/DefaultSettings.php
 
+version: '3'
 services:
   database:
     container_name: micro-pkc-database-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@
 #
 # See comment in docker-compose.dev.yml if you want to run for development.
 
-version: '3'
-
 services:
   database:
     container_name: micro-pkc-database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   mediawiki:
     container_name: micro-pkc-mediawiki
-    image: inblockio/micro-pkc-mediawiki:1.0.0-alpha.3
+    image: inblockio/micro-pkc-mediawiki:1.0.0-alpha.4
     restart: always
     networks:
       - common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@
 #
 # See comment in docker-compose.dev.yml if you want to run for development.
 
+version: '3'
+
 services:
   database:
     container_name: micro-pkc-database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,8 @@ services:
 
   siwe-oidc:
     image: ghcr.io/spruceid/siwe_oidc:latest
-    hostname: siwe-oidc
     ports:
-      #init SIWEOIDC_IP to correctly bind container to host
-      - ${SIWEOIDC_IP}${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
+      - ${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
     environment:
       SIWEOIDC_ADDRESS: "0.0.0.0"
       SIWEOIDC_REDIS_URL: "redis://redis"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,10 @@ services:
 
   siwe-oidc:
     image: ghcr.io/spruceid/siwe_oidc:latest
+    hostname: siwe-oidc
     ports:
-      - ${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
+      #init SIWEOIDC_IP to correctly bind container to host
+      - ${SIWEOIDC_IP}${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
     environment:
       SIWEOIDC_ADDRESS: "0.0.0.0"
       SIWEOIDC_REDIS_URL: "redis://redis"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - LETSENCRYPT_HOST=${MEDIAWIKI_HOST}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - SIWEOIDC_PORT=${SIWEOIDC_PORT}
+      - SIWEOIDC_HOST=${SIWEOIDC_HOST}
     volumes:
       - ./mountPoint/images:/var/www/html/images
       - ./mountPoint/extensions/DataAccounting:/var/www/html/extensions/DataAccounting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - siwe-oidc
 
   siwe-oidc:
-    image: ghcr.io/spruceid/siwe_oidc:latest
+    image: ghcr.io/spruceid/siwe_oidc:20221208081605782143
     ports:
       - ${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,7 @@ services:
     networks:
       - common
     environment:
-      # The following line is replaced by a script in
-      # provision/mariadb/01-databases.sql because we need to initialize 2
-      # databases: my_wiki and eauth.
-      # MYSQL_DATABASE: my_wiki
+      MYSQL_DATABASE: my_wiki
       MYSQL_USER: wikiuser
       MYSQL_PASSWORD: example
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
@@ -29,7 +26,7 @@ services:
 
   mediawiki:
     container_name: micro-pkc-mediawiki
-    image: inblockio/micro-pkc-mediawiki:1.0.0-alpha.2
+    image: inblockio/micro-pkc-mediawiki:1.0.0-alpha.3
     restart: always
     networks:
       - common
@@ -43,7 +40,7 @@ services:
       - VIRTUAL_HOST=${MEDIAWIKI_HOST}
       - LETSENCRYPT_HOST=${MEDIAWIKI_HOST}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
-      - EAUTH_PORT=${EAUTH_PORT}
+      - SIWEOIDC_PORT=${SIWEOIDC_PORT}
     volumes:
       - ./mountPoint/images:/var/www/html/images
       - ./mountPoint/extensions/DataAccounting:/var/www/html/extensions/DataAccounting
@@ -52,28 +49,43 @@ services:
       - ./mountPoint/MediaWiki_Backup:/MediaWiki_Backup
     depends_on:
       - database
-      - eauth
+      - siwe-oidc
 
-  eauth:
-    container_name: micro-pkc-eauth
-    image: inblockio/micro-pkc-eauth:1.0.0-alpha
+  siwe-oidc:
+    image: ghcr.io/spruceid/siwe_oidc:latest
+    ports:
+      - ${SIWEOIDC_PORT}:${SIWEOIDC_PORT}
+    environment:
+      SIWEOIDC_ADDRESS: "0.0.0.0"
+      SIWEOIDC_REDIS_URL: "redis://redis"
+      SIWEOIDC_DEFAULT_CLIENTS: ${SIWEOIDC_DEFAULT_CLIENTS}
+      SIWEOIDC_BASE_URL: ${SIWEOIDC_BASE_URL}
+      RUST_LOG: "siwe_oidc=debug,tower_http=debug"
+      VIRTUAL_HOST: ${SIWEOIDC_HOST}
+      LETSENCRYPT_HOST: ${SIWEOIDC_HOST}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+    env_file:
+      - .env
+    depends_on:
+      - redis
     restart: always
     networks:
       - common
       # Do not delete the comment below! It is used for adding an external
       # network for deploying an internet-accessible PKC .
       #WEBPUBLICPLACEHOLDER
-    env_file:
-      - .env
+
+  redis:
+    image: redis
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
-      - ${EAUTH_PORT}:${EAUTH_PORT}
-    environment:
-      - VIRTUAL_HOST=${EAUTH_HOST}
-      - LETSENCRYPT_HOST=${EAUTH_HOST}
-      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
-      - VIRTUAL_PORT=${EAUTH_PORT}
-    depends_on:
-      - database
+      - "6379:6379"
+    networks:
+      - common
 
 networks:
   # We specify the internal network as common, so that the services in this

--- a/pkc
+++ b/pkc
@@ -301,7 +301,7 @@ run_setup() {
 
     # Convert wallet address to lower case
     # This is because the address returned in Metamask API is in lower case
-    WALLET_ADDRESS=$(echo "$WALLET_ADDRESS" | tr "\[A-Z\]" "\[a-z\]")
+    # WALLET_ADDRESS=$(echo "$WALLET_ADDRESS" | tr "\[A-Z\]" "\[a-z\]")
 
     ensure_submodules
 

--- a/pkc
+++ b/pkc
@@ -330,7 +330,17 @@ run_setup() {
 
     # We always download the favicon fresh, so that it is always up to date.
     echo "Downloading browser favicon"
-    sudo docker exec micro-pkc-mediawiki curl https://raw.githubusercontent.com/inblockio/aqua-branding/main/logos/aqua-white-1024x1024-32x32.png -o favicon.ico
+
+    # Setting a timeout for the curl command and redirecting stderr to stdout to handle both output and error
+    if timeout 15 sudo docker exec micro-pkc-mediawiki bash -c "curl https://raw.githubusercontent.com/inblockio/aqua-branding/main/logos/aqua-white-1024x1024-32x32.png -o favicon.ico 2>&1"; then
+        echo "Download favicon successful."
+    else
+        # This block executes if curl fails due to timeout or any other reason
+        case $? in
+            124) echo "Favicon download failed after 15 seconds (time out)." ;;
+            *) echo "The command failed for a different reason." ;;
+        esac
+    fi
 
     # Prepare auto backup
     sudo cp aqua/do_backup_wrapper.sh mountPoint/backup

--- a/pkc
+++ b/pkc
@@ -293,7 +293,7 @@ run_setup() {
             PKC_SERVER=http://localhost:9352
         fi
 		if [ -z "$SIWEOIDC_SERVER" ];  then
-			SIWEOIDC_SERVER=http://siwe-oidc:9353
+			SIWEOIDC_SERVER=http://localhost:9353
 		fi
         echo "Server name: $PKC_SERVER"
 		echo "SIWE server: $SIWEOIDC_SERVER"
@@ -305,7 +305,7 @@ run_setup() {
 
     ensure_submodules
 
-    echo "Specifying the server name into SIWE OIDC"
+	echo "Specifying the server name into SIWE OIDC"
     # use perl to account for cross-OS limitations of sed
     # https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux/14813278#14813278
     perl -i -p -e "s|PKC_SERVER|$PKC_SERVER|" .env
@@ -320,6 +320,12 @@ run_setup() {
     sleep 10
 
     echo "Installing MediaWiki"
+	if [ "$SIWEOIDC_SERVER" = "http://localhost:9353" ]; then
+		siwe_container_name=$(sudo docker compose ps --format '{{.Name}}' siwe-oidc)
+		siwe_container_ip_address=$(sudo docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$siwe_container_name")
+		SIWEOIDC_SERVER="http://$siwe_container_ip_address:9353"
+		echo "local SIWE server is now: $SIWEOIDC_SERVER"
+	fi
     # TODO split failure cases and remove || true
     sudo docker exec micro-pkc-mediawiki ./aqua/install_pkc.sh \
                         --wallet-address "$WALLET_ADDRESS" \

--- a/pkc
+++ b/pkc
@@ -39,7 +39,7 @@ Options:
   -w, --wallet-address <your crypto wallet address>
   -s, --server         <your server name; defaults to http://localhost:9352>
   --private             disable anonymous page read
-  --web-public          expect --server <mediawiki.domain> --eauth-server <eauth.domain> --le-email <your@email.com>
+  --web-public          expect --server <mediawiki.domain> --siwe-server <siwe.domain> --le-email <your@email.com>
   --empty-wiki          setup without default wiki content
   --disable-autobackup  disable MediaWiki auto backup service
 EOF
@@ -150,7 +150,7 @@ ensure_submodules() {
 
 validate_web_public_detail() {
     local pkc_server=$1
-    local eauth_server=$2
+    local siweoidc_server=$2
     local letsencrypt_email=$3
     if [ -z "$pkc_server" ]; then
         echo "Error: You specified '--web-public' but didn't specify the MediaWiki server via '--server'"
@@ -160,12 +160,12 @@ validate_web_public_detail() {
         echo "Error: Your MediaWiki server must not contain the https scheme"
         exit 1
     fi
-    if [ -z "$eauth_server" ]; then
-        echo "Error: You specified '--web-public' but didn't specify the Eauth server via '--eauth-server'"
+    if [ -z "$siweoidc_server" ]; then
+        echo "Error: You specified '--web-public' but didn't specify the SIWE OIDC server via '--siweoidc-server'"
         exit 1
     fi
-    if [[ "$eauth_server" == *"https:"* ]]; then
-        echo "Error: Your Eauth server must not contain the https scheme"
+    if [[ "$siweoidc_server" == *"https:"* ]]; then
+        echo "Error: Your SIWE OIDC server must not contain the https scheme"
         exit 1
     fi
     if [ -z "$letsencrypt_email" ]; then
@@ -188,12 +188,12 @@ setup_proxy_server() {
 
 prepare_web_public() {
     local pkc_server=$1
-    local eauth_server=$2
+    local siweoidc_server=$2
     local letsencrypt_email=$3
     setup_proxy_server
     echo "Applying your domain details"
     sed -i "s|MEDIAWIKI_HOST=.*|MEDIAWIKI_HOST=$pkc_server|" .env
-    sed -i "s|EAUTH_HOST=.*|EAUTH_HOST=$eauth_server|" .env
+    sed -i "s|SIWEOIDC_HOST=.*|SIWEOIDC_HOST=$siweoidc_server|" .env
     sed -i "s/LETSENCRYPT_EMAIL=.*/LETSENCRYPT_EMAIL=$letsencrypt_email/" .env
     if ! grep -q "proxy_server_net" docker-compose.yml; then
         echo "  proxy_server_net:" >> docker-compose.yml
@@ -234,8 +234,8 @@ run_setup() {
                 shift
                 shift
                 ;;
-            --eauth-server)
-                EAUTH_SERVER="$2"
+            --siweoidc-server)
+                SIWEOIDC_SERVER="$2"
                 shift
                 shift
                 ;;
@@ -280,19 +280,23 @@ run_setup() {
     fi
 
     if [ "$web_public" = true ]; then
-        validate_web_public_detail "$PKC_SERVER" "$EAUTH_SERVER" "$LETSENCRYPT_EMAIL"
+        validate_web_public_detail "$PKC_SERVER" "$SIWEOIDC_SERVER" "$LETSENCRYPT_EMAIL"
         echo "MediaWiki server name: $PKC_SERVER"
-        echo "Eauth server name: $EAUTH_SERVER"
+        echo "SIWE OIDC server name: $SIWEOIDC_SERVER"
         echo "Let's Encrypt email: $LETSENCRYPT_EMAIL"
-        prepare_web_public "$PKC_SERVER" "$EAUTH_SERVER" "$LETSENCRYPT_EMAIL"
+        prepare_web_public "$PKC_SERVER" "$SIWEOIDC_SERVER" "$LETSENCRYPT_EMAIL"
         # Add https:// scheme
         PKC_SERVER="https://$PKC_SERVER"
-        EAUTH_SERVER="https://$EAUTH_SERVER"
+        SIWEOIDC_SERVER="https://$SIWEOIDC_SERVER"
     else
         if [ -z "$PKC_SERVER" ]; then
             PKC_SERVER=http://localhost:9352
         fi
+		if [ -z "$SIWEOIDC_SERVER" ];  then
+			SIWEOIDC_SERVER=http://localhost:9353
+		fi
         echo "Server name: $PKC_SERVER"
+		echo "SIWE server: $SIWEOIDC_SERVER"
     fi
 
     # Convert wallet address to lower case
@@ -301,10 +305,11 @@ run_setup() {
 
     ensure_submodules
 
-    echo "Specifying the server name into Eauth"
+    echo "Specifying the server name into SIWE OIDC"
     # use perl to account for cross-OS limitations of sed
     # https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux/14813278#14813278
     perl -i -p -e "s|PKC_SERVER|$PKC_SERVER|" .env
+	perl -i -p -e "s|SIWEOIDC_SERVER|$SIWEOIDC_SERVER|" .env
 
     echo "Executing docker-compose up -d. Be prepared to type your password."
     # Support version 1 / 2 of docker-compose
@@ -319,16 +324,13 @@ run_setup() {
     sudo docker exec micro-pkc-mediawiki ./aqua/install_pkc.sh \
                         --wallet-address "$WALLET_ADDRESS" \
                         --pkc-server "$PKC_SERVER" \
-                        --eauth-server "$EAUTH_SERVER" \
+                        --siweoidc-server "$SIWEOIDC_SERVER" \
                         ${empty_wiki:+--empty-wiki} \
                         ${private:+--private} || true
 
     # We always download the favicon fresh, so that it is always up to date.
     echo "Downloading browser favicon"
     sudo docker exec micro-pkc-mediawiki curl https://raw.githubusercontent.com/inblockio/aqua-branding/main/logos/aqua-white-1024x1024-32x32.png -o favicon.ico
-
-    # TODO REMOVE THIS ONCE PELITH HAS FIXED THEIR RETRY BUG
-    sudo docker exec micro-pkc-eauth pkill node
 
     # Prepare auto backup
     sudo cp aqua/do_backup_wrapper.sh mountPoint/backup

--- a/pkc
+++ b/pkc
@@ -293,7 +293,7 @@ run_setup() {
             PKC_SERVER=http://localhost:9352
         fi
 		if [ -z "$SIWEOIDC_SERVER" ];  then
-			SIWEOIDC_SERVER=http://localhost:9353
+			SIWEOIDC_SERVER=http://siwe-oidc:9353
 		fi
         echo "Server name: $PKC_SERVER"
 		echo "SIWE server: $SIWEOIDC_SERVER"

--- a/pkc
+++ b/pkc
@@ -293,7 +293,7 @@ run_setup() {
             PKC_SERVER=http://localhost:9352
         fi
 		if [ -z "$SIWEOIDC_SERVER" ];  then
-			SIWEOIDC_SERVER=http://localhost:9353
+			SIWEOIDC_SERVER=http://siwe-oidc:9353
 		fi
         echo "Server name: $PKC_SERVER"
 		echo "SIWE server: $SIWEOIDC_SERVER"
@@ -305,7 +305,7 @@ run_setup() {
 
     ensure_submodules
 
-	echo "Specifying the server name into SIWE OIDC"
+    echo "Specifying the server name into SIWE OIDC"
     # use perl to account for cross-OS limitations of sed
     # https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux/14813278#14813278
     perl -i -p -e "s|PKC_SERVER|$PKC_SERVER|" .env
@@ -320,12 +320,6 @@ run_setup() {
     sleep 10
 
     echo "Installing MediaWiki"
-	if [ "$SIWEOIDC_SERVER" = "http://localhost:9353" ]; then
-		siwe_container_name=$(sudo docker compose ps --format '{{.Name}}' siwe-oidc)
-		siwe_container_ip_address=$(sudo docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$siwe_container_name")
-		SIWEOIDC_SERVER="http://$siwe_container_ip_address:9353"
-		echo "local SIWE server is now: $SIWEOIDC_SERVER"
-	fi
     # TODO split failure cases and remove || true
     sudo docker exec micro-pkc-mediawiki ./aqua/install_pkc.sh \
                         --wallet-address "$WALLET_ADDRESS" \

--- a/pkc
+++ b/pkc
@@ -109,8 +109,8 @@ ensure_submodules() {
     mkdir -p mountPoint/extensions
 
     # Ensure DataAccounting repo exists
-    local version=v1.0.0-alpha.3  # Remember to update version_timestamp variable below
-    local version_timestamp=1643351163
+    local version=v1.0.0-alpha.4  # Remember to update version_timestamp variable below
+    local version_timestamp=1713019795
     if [ ! -d ../DataAccounting ]; then
         echo "DataAccounting repo doesn't exist. Downloading..."
         # We need to do this line in a subshell so that the current directory is

--- a/pkc
+++ b/pkc
@@ -293,7 +293,7 @@ run_setup() {
             PKC_SERVER=http://localhost:9352
         fi
 		if [ -z "$SIWEOIDC_SERVER" ];  then
-			SIWEOIDC_SERVER=http://siwe-oidc:9353
+			SIWEOIDC_SERVER=http://localhost:9353
 		fi
         echo "Server name: $PKC_SERVER"
 		echo "SIWE server: $SIWEOIDC_SERVER"

--- a/provision/mariadb/01-databases.sql
+++ b/provision/mariadb/01-databases.sql
@@ -1,7 +1,0 @@
-# See https://stackoverflow.com/questions/39204142/docker-compose-with-multiple-databases/39204865.
-# create databases
-CREATE DATABASE IF NOT EXISTS `my_wiki`;
-CREATE DATABASE IF NOT EXISTS `eauth`;
-
-GRANT ALL PRIVILEGES ON my_wiki.* TO 'wikiuser'@'%';
-GRANT ALL PRIVILEGES ON eauth.* TO 'wikiuser'@'%';

--- a/scripts/allow_user_creation.sh
+++ b/scripts/allow_user_creation.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check if the script is run as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script needs to be run with sudo."
+  exit 1
+fi
+
+# Place your script commands here
+echo "Running with sufficient privileges."
+
+# Define the path to the file relative to the script location
+FILE_PATH="../mountPoint/backup/LocalSettings.php"
+
+# Check if the file exists
+if [ ! -f "$FILE_PATH" ]; then
+    echo "Error: $FILE_PATH does not exist."
+    exit 1
+fi
+
+# Use sed to modify the file in-place
+sed -i "s/\$wgGroupPermissions\['\*'\]\['createaccount'\] = false;/\$wgGroupPermissions['*']['createaccount'] = true;/g" "$FILE_PATH"
+
+echo "Modified $FILE_PATH to enable account creation."
+

--- a/scripts/remove_etc_hosts_entry_for_siwe_oidc.sh
+++ b/scripts/remove_etc_hosts_entry_for_siwe_oidc.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Check if the script is run as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script needs to be run with sudo."
+  exit 1
+fi
+
+# Define the hostname
+HOSTNAME="siwe-oidc"
+
+# Remove the entry from /etc/hosts
+sudo sed -i "/$HOSTNAME/d" /etc/hosts
+echo "Removed $HOSTNAME entry from /etc/hosts."
+

--- a/scripts/update_etc_hosts_for_siwe_oidc.sh
+++ b/scripts/update_etc_hosts_for_siwe_oidc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if the script is run as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script needs to be run with sudo."
+  exit 1
+fi
+
+# Retrieve the IP address from the docker inspect command
+IP_ADDRESS=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' aqua-pkc_siwe-oidc_1)
+
+# Define the hostname
+HOSTNAME="siwe-oidc"
+
+# Check if the entry exists in the /etc/hosts
+grep -q "$HOSTNAME" /etc/hosts
+
+if [ $? -eq 0 ]; then
+    # Entry exists, check if IP address is the same
+    CURRENT_IP=$(grep "$HOSTNAME" /etc/hosts | awk '{print $1}')
+    if [ "$CURRENT_IP" != "$IP_ADDRESS" ]; then
+        # IP address is different, update the entry
+        sudo sed -i "/$HOSTNAME/c\\$IP_ADDRESS\t$HOSTNAME" /etc/hosts
+        echo "Updated $HOSTNAME entry to IP $IP_ADDRESS in /etc/hosts."
+    else
+        echo "$HOSTNAME entry is already up to date."
+    fi
+else
+    # Entry does not exist, add it
+    echo "$IP_ADDRESS      $HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
+    echo "Added $HOSTNAME entry with IP $IP_ADDRESS to /etc/hosts."
+fi
+


### PR DESCRIPTION
This PR includes:

- Replace Eauth and OAuth.2 with SIWE and OIDC
- Mediawiki 1.39 upgrade
- Bump mediawiki-extension-Aqua to support alpha.4 release which includes the new Ethereum testnetworks

For all changes see commit messages of:

- https://github.com/inblockio/mediawiki-extensions-Aqua
- https://github.com/inblockio/aqua-docker-mediawiki