### PR TITLE
Fix SIWE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       SIWEOIDC_BASE_URL: ${SIWEOIDC_BASE_URL}
       RUST_LOG: "siwe_oidc=debug,tower_http=debug"
       VIRTUAL_HOST: ${SIWEOIDC_HOST}
+      VIRTUAL_PORT: ${SIWEOIDC_PORT}
       LETSENCRYPT_HOST: ${SIWEOIDC_HOST}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
     env_file:

--- a/pkc
+++ b/pkc
@@ -39,7 +39,7 @@ Options:
   -w, --wallet-address <your crypto wallet address>
   -s, --server         <your server name; defaults to http://localhost:9352>
   --private             disable anonymous page read
-  --web-public          expect --server <mediawiki.domain> --siwe-server <siwe.domain> --le-email <your@email.com>
+  --web-public          expect --server <mediawiki.domain> --siweoidc-server <siwe.domain> --le-email <your@email.com>
   --empty-wiki          setup without default wiki content
   --disable-autobackup  disable MediaWiki auto backup service
 EOF

--- a/proxy_server/docker-compose.yml
+++ b/proxy_server/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   proxy:
     image: nginxproxy/nginx-proxy:alpine
+    container_name: proxy_server_proxy_1
     labels:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true"
     networks:
@@ -20,6 +21,7 @@ services:
 
   letsencrypt:
     image: nginxproxy/acme-companion:latest
+    container_name: proxy_server_letsencrypt_1
     depends_on:
       - proxy
     networks:


### PR DESCRIPTION
Problem:
- Nginx exposed the 'default port,' which means port 80.
-> This is the default configuration if a container has multiple ports exposed.

Solution:
- If we set the VIRTUAL_PORT (similar to the MediaWiki container), Nginx will find the correct port and expose it.

other:
add docker_name

if the docker name changes, the pkc script no longer works.

Fix #134