### PR TITLE
Add docker-compose-local

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,10 +1,13 @@
 MEDIAWIKI_HOST=pkc.yourdomain.com
 LETSENCRYPT_EMAIL=you@youremaildomain.com
 
-# MediaWiki port Number
-MEDIAWIKI_PORT=9352
 
 SIWEOIDC_PORT=9353
 SIWEOIDC_HOST=localhost
 SIWEOIDC_BASE_URL="SIWEOIDC_SERVER"
 SIWEOIDC_DEFAULT_CLIENTS='{siwe="{\"secret\":\"siweaqua\", \"metadata\": {\"redirect_uris\": [\"PKC_SERVER/index.php/Special:PluggableAuthLogin\"]}}"}'
+
+
+# only local deployment
+# MediaWiki port Number
+MEDIAWIKI_PORT=9352

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ docker-compose.override.yml
 mountPoint
 aqua/MediaWiki_Backup
 .env
+/.idea/
+/proxy_server/proxy/
+/aqua-PKC.iml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ aqua/MediaWiki_Backup
 /.idea/
 /proxy_server/proxy/
 /aqua-PKC.iml
+/.autobackup

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,8 +1,5 @@
-# This Docker Compose file is used to run the project's published image
-#
-# Usage: docker compose up [-d] [--env-file=path/to/file]
-#
-# See comment in docker-compose.dev.yml if you want to run for development.
+# do not start this compose-file!
+#use ./pkc.... instead
 
 version: '3'
 
@@ -11,6 +8,8 @@ services:
     container_name: micro-pkc-database
     image: mariadb:10.6.5
     restart: always
+    ports:
+      - "3306:3306"
     networks:
       - common
     environment:
@@ -30,9 +29,6 @@ services:
     restart: always
     networks:
       - common
-      # Do not delete the comment below! It is used for adding an external
-      # network for deploying an internet-accessible PKC .
-      #WEBPUBLICPLACEHOLDER
     ports:
       - ${MEDIAWIKI_PORT}:80
     entrypoint: '/var/www/html/aqua/entrypoint_mediawiki.sh'
@@ -73,9 +69,6 @@ services:
     restart: always
     networks:
       - common
-      # Do not delete the comment below! It is used for adding an external
-      # network for deploying an internet-accessible PKC .
-      #WEBPUBLICPLACEHOLDER
 
   redis:
     image: redis
@@ -90,8 +83,5 @@ services:
       - common
 
 networks:
-  # We specify the internal network as common, so that the services in this
-  # docker-compose.yml can be configured to interact with the services in the
-  # other, separate docker-compose.yml using external networks.
   common:
 

--- a/docker-compose-web.yml
+++ b/docker-compose-web.yml
@@ -1,0 +1,83 @@
+# do not start this compose-file!
+#use ./pkc.... instead
+
+version: '3'
+
+services:
+  database:
+    container_name: micro-pkc-database
+    image: mariadb:10.6.5
+    restart: always
+    networks:
+      - common
+    environment:
+      MYSQL_DATABASE: my_wiki
+      MYSQL_USER: wikiuser
+      MYSQL_PASSWORD: example
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+    volumes:
+      - ./mountPoint/mariadb:/var/lib/mysql
+      - ./provision/mariadb:/docker-entrypoint-initdb.d
+      - ./mountPoint/backup:/backup
+      - ./mountPoint/MediaWiki_Backup:/MediaWiki_Backup
+
+  mediawiki:
+    container_name: micro-pkc-mediawiki
+    image: inblockio/micro-pkc-mediawiki:1.0.0-alpha.4
+    restart: always
+    networks:
+      - common
+      - proxy_server_net
+    entrypoint: '/var/www/html/aqua/entrypoint_mediawiki.sh'
+    environment:
+      - VIRTUAL_HOST=${MEDIAWIKI_HOST}
+      - LETSENCRYPT_HOST=${MEDIAWIKI_HOST}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+      - SIWEOIDC_PORT=${SIWEOIDC_PORT}
+      - SIWEOIDC_HOST=${SIWEOIDC_HOST}
+    volumes:
+      - ./mountPoint/images:/var/www/html/images
+      - ./mountPoint/extensions/DataAccounting:/var/www/html/extensions/DataAccounting
+      - ./mountPoint/backup:/backup
+      - ./aqua:/var/www/html/aqua
+      - ./mountPoint/MediaWiki_Backup:/MediaWiki_Backup
+    depends_on:
+      - database
+      - siwe-oidc
+
+  siwe-oidc:
+    image: ghcr.io/spruceid/siwe_oidc:20221208081605782143
+    environment:
+      SIWEOIDC_ADDRESS: "0.0.0.0"
+      SIWEOIDC_REDIS_URL: "redis://redis"
+      SIWEOIDC_DEFAULT_CLIENTS: ${SIWEOIDC_DEFAULT_CLIENTS}
+      SIWEOIDC_BASE_URL: ${SIWEOIDC_BASE_URL}
+      RUST_LOG: "siwe_oidc=debug,tower_http=debug"
+      VIRTUAL_HOST: ${SIWEOIDC_HOST}
+      VIRTUAL_PORT: ${SIWEOIDC_PORT}
+      LETSENCRYPT_HOST: ${SIWEOIDC_HOST}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+    env_file:
+      - .env
+    depends_on:
+      - redis
+    restart: always
+    networks:
+      - common
+      - proxy_server_net
+
+  redis:
+    image: redis
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - common
+
+networks:
+  common:
+  proxy_server_net:
+    external: true
+

--- a/pkc
+++ b/pkc
@@ -203,7 +203,7 @@ prepare_dotenv() {
 }
 
 do_docker_compose_up_maybe_backup() {
-    if [ -z "$web_public" ]; then
+    if [ "$web_public" = true ]; then
       sudo docker-compose -f docker-compose-web.yml up -d
     else
       sudo docker-compose -f docker-compose-local.yml up -d
@@ -425,6 +425,7 @@ while [[ $# -gt 0 ]]; do
 #                    check if proxy_server_net network exists. if true = web_public
                     if [[ $(sudo docker network ls | grep proxy_server_net ) ]]; then
                       sudo docker-compose -f docker-compose-web.yml down
+                      sudo docker network rm proxy_server_net
                     else
                       sudo docker-compose -f docker-compose-local.yml down
                     fi

--- a/pkc
+++ b/pkc
@@ -195,11 +195,6 @@ prepare_web_public() {
     sed -i "s|MEDIAWIKI_HOST=.*|MEDIAWIKI_HOST=$pkc_server|" .env
     sed -i "s|SIWEOIDC_HOST=.*|SIWEOIDC_HOST=$siweoidc_server|" .env
     sed -i "s/LETSENCRYPT_EMAIL=.*/LETSENCRYPT_EMAIL=$letsencrypt_email/" .env
-    if ! grep -q "proxy_server_net" docker-compose.yml; then
-        echo "  proxy_server_net:" >> docker-compose.yml
-        echo "    external: true" >> docker-compose.yml
-        sed -i "s/#WEBPUBLICPLACEHOLDER/- proxy_server_net/" docker-compose.yml
-    fi
 }
 
 prepare_dotenv() {
@@ -208,7 +203,11 @@ prepare_dotenv() {
 }
 
 do_docker_compose_up_maybe_backup() {
-    sudo docker-compose up -d
+    if [ -z "$web_public" ]; then
+      sudo docker-compose -f docker-compose-web.yml up -d
+    else
+      sudo docker-compose -f docker-compose-local.yml up -d
+    fi
     if [ -f .autobackup ]; then
         echo "Starting cron for auto-backup"
         sudo docker exec micro-pkc-mediawiki service cron start
@@ -423,7 +422,12 @@ while [[ $# -gt 0 ]]; do
                 [yY][eE][sS]|[yY])
                     echo "💥💥💥💥 Kaaboooom!!!💥💥💥💥"
                     set -x
-                    sudo docker-compose down
+#                    check if proxy_server_net network exists. if true = web_public
+                    if [[ $(sudo docker network ls | grep proxy_server_net ) ]]; then
+                      sudo docker-compose -f docker-compose-web.yml down
+                    else
+                      sudo docker-compose -f docker-compose-local.yml down
+                    fi
                     sudo rm -r mountPoint
                     set +x
                     echo "🏜️ It's all gone 🏜️"


### PR DESCRIPTION
Docker-Compose has been split into 2 files. One is intended for local deployment and the other for web deployment.
For local deployment, all ports are opened (for debugging).
For web deployment, only the ports from the proxy are opened, as only communication should/may run through it.
The pkc script has been adjusted so that it can handle these 2 different Docker-Compose files.