### PR TITLE
fix redis startup

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -78,6 +78,7 @@ services:
       retries: 5
     ports:
       - "6379:6379"
+    restart: always
     networks:
       - common
 

--- a/docker-compose-web.yml
+++ b/docker-compose-web.yml
@@ -72,6 +72,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    restart: always
     networks:
       - common
 


### PR DESCRIPTION
Since Redis did not come back up after a restart, restart: always was added to the Docker Compose. This should resolve the issue.

fix https://github.com/inblockio/aqua-PKC/issues/149